### PR TITLE
Improve branding text style

### DIFF
--- a/offline-llm-ui/src/components/AppFooter/AppFooter.tsx
+++ b/offline-llm-ui/src/components/AppFooter/AppFooter.tsx
@@ -1,6 +1,10 @@
-import { Flex, useColorModeValue } from "@chakra-ui/react";
+import { Flex, Text, useColorModeValue } from "@chakra-ui/react";
 
 export function AppFooter() {
+  const footerGradient = useColorModeValue(
+    "linear(to-r, purple.600, blue.600)",
+    "linear(to-r, purple.300, cyan.300)"
+  );
   return (
     <Flex
       as="footer"
@@ -18,7 +22,17 @@ export function AppFooter() {
       bottom={0}
       zIndex={10} // keep above any content scrollbars
     >
-      © {new Date().getFullYear()} EklavyaAI · Simulator Development Division (Devp and Designed by @hariomahlawat)
+      © {new Date().getFullYear()} EklavyaAI ·
+      <Text
+        as="span"
+        bgGradient={footerGradient}
+        bgClip="text"
+        fontFamily="'Trebuchet MS','Segoe UI','Helvetica Neue',Arial,sans-serif"
+        fontWeight={700}
+      >
+        Simulator Development Division
+      </Text>{" "}
+      (Devp and Designed by @hariomahlawat)
     </Flex>
   );
 }

--- a/offline-llm-ui/src/components/AppHeader/AppHeader.tsx
+++ b/offline-llm-ui/src/components/AppHeader/AppHeader.tsx
@@ -97,6 +97,10 @@ export function AppHeader() {
   const matteBg = useColorModeValue("gray.100", "#22232b");
   const orgColor = useColorModeValue("gray.700", "#e8eaf3");
   const mainHeadingColor = useColorModeValue("blue.600", "#ffe3a3");
+  const orgGradient = useColorModeValue(
+    "linear(to-r, purple.600, blue.600)",
+    "linear(to-r, purple.300, cyan.300)"
+  );
   const subtitleColor = useColorModeValue("gray.500", "#b8bdc9");
 
   const isMobile = useBreakpointValue({ base: true, md: false });
@@ -158,9 +162,12 @@ export function AppHeader() {
           <Heading
             fontSize={isMobile ? "md" : "xl"}
             fontWeight={700}
-            color={orgColor}
             letterSpacing="wide"
             textAlign="center"
+            bgGradient={orgGradient}
+            bgClip="text"
+            color="transparent"
+            fontFamily="'Trebuchet MS','Segoe UI','Helvetica Neue',Arial,sans-serif"
           >
             Simulator&nbsp;Development&nbsp;Division
           </Heading>


### PR DESCRIPTION
## Summary
- style "Simulator Development Division" text in header and footer
- add color gradient and modern font fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876fb0228e4832984ece087a6c52f31