### PR TITLE
Add LANGCHAIN_TELEMETRY_ENABLED to backend image

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -42,7 +42,8 @@ RUN set -eux; \
 ENV OLLAMA_HOST=http://ollama:11434 \
     CHROMA_TELEMETRY=FALSE \
     PERSIST_CHROMA_DIR=/app/data/chroma_persist \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    LANGCHAIN_TELEMETRY_ENABLED=false
 
 RUN mkdir -p /app/data/chroma_persist && chown -R llm:llm /app/data
 


### PR DESCRIPTION
## Summary
- disable LangChain telemetry inside backend runtime image

## Testing
- `docker build -f docker/Dockerfile.backend -t offline_llm_backend .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877167b11e88329a8ca701763073664