### PR TITLE
Resolve npm build issue with React 19

### DIFF
--- a/offline-llm-ui/package-lock.json
+++ b/offline-llm-ui/package-lock.json
@@ -31,7 +31,9 @@
         "globals": "^16.2.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.34.1",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5416,6 +5418,48 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     }
   }

--- a/offline-llm-ui/package.json
+++ b/offline-llm-ui/package.json
@@ -35,7 +35,7 @@
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.0"
     ,"vitest": "^1.4.0"
-    ,"@testing-library/react": "^14.1.2"
-    ,"@testing-library/user-event": "^14.4.3"
+    ,"@testing-library/react": "^16.3.0"
+    ,"@testing-library/user-event": "^14.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade `@testing-library/react` and `@testing-library/user-event` in the frontend
- sync versions in `package-lock.json`

These updates fix a dependency conflict when building the frontend with React 19.

## Testing
- `python3 -m json.tool offline-llm-ui/package-lock.json`

------
https://chatgpt.com/codex/tasks/task_e_6877236ca0e483298acc2a3f126874c3