### PR TITLE
Document testing certificate

### DIFF
--- a/certs/README.md
+++ b/certs/README.md
@@ -1,1 +1,11 @@
+# SSL Certificate
+
+The `server.crt` and `server.key` files bundled in this repository are **example certificates** for development and testing only. They should not be used in production.
+
+For a real deployment, generate a fresh self‑signed certificate:
+
+```bash
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt
+```
+
+Place the resulting `server.crt` and `server.key` under the `certs/` directory before building the Docker images or starting Nginx.


### PR DESCRIPTION
## Summary
- clarify that `certs/server.crt` is an example certificate
- show how to create a new certificate for production use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877207453b88329bcb5e8e31674bbd1