### PR TITLE
Update docs and workflows for Python 3.13

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -2,7 +2,7 @@
 # This Dockerfile builds the Python backend, installs dependencies, and sets up the environment for running the application
 
 ########################  builder  ########################
-FROM python:3.11-slim AS builder
+FROM python:3.13-slim AS builder
 
 ARG LANGCHAIN_TELEMETRY_ENABLED=false
 ENV LANGCHAIN_TELEMETRY_ENABLED=${LANGCHAIN_TELEMETRY_ENABLED}
@@ -18,7 +18,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # ───────────────────────────  runtime  ────────────────────────────
-FROM python:3.11-slim
+FROM python:3.13-slim
 WORKDIR /app
 
 # Python deps

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -11,7 +11,7 @@
 | Tool | Minimum version | Install notes |
 |------|-----------------|---------------|
 | **Git** | any recent | <https://git-scm.com/download/win> – add **git.exe** to PATH |
-| **Python** | 3.11 × 64‑bit | `python --version` ⇒ *3.11.x* |
+| **Python** | 3.13 × 64‑bit | `python --version` ⇒ *3.13.x* |
 | **Docker Desktop** | 4.42 + | enable **“Use the WSL 2 based engine”** |
 | **Ollama** | 0.3.4 (inside container) | models pulled automatically |
 | **VS Code** | optional | Python + Docker extensions help |
@@ -54,7 +54,7 @@ pip-compile docker\requirements.in -o requirements.lock
 pip install -r requirements.lock
 ```
 
-The lock file is generated using **Python 3.11**. Run `pip-compile` with the same version to avoid mismatched hashes.
+The lock file is generated using **Python 3.13**. Run `pip-compile` with the same version to avoid mismatched hashes.
 
 For speech-to-text support install **ffmpeg** and the `whisper` Python package:
 
@@ -197,7 +197,7 @@ pip install -r requirements.lock
 docker compose build rag-app
 ```
 
-Run the locking step with **Python 3.11** so dependency hashes match the
+Run the locking step with **Python 3.13** so dependency hashes match the
 published `requirements.lock`.
 
 ---


### PR DESCRIPTION
## Summary
- use python `3.13-slim` in backend Dockerfile
- run tests with Python `3.13`
- document that dev setup and pip‑compile use Python 3.13

## Testing
- `pytest -q`
- ❌ `docker compose build` *(fails: `command not found`)*
- ❌ `python -m piptools compile` *(fails: `No module named piptools`)*

------
https://chatgpt.com/codex/tasks/task_e_687a2646827083298d3f159c098cc7b2