### PR TITLE
Update import paths for Ollama and Chroma

### DIFF
--- a/app/vector_store.py
+++ b/app/vector_store.py
@@ -17,8 +17,8 @@ import logging
 
 import chromadb
 from chromadb.config import Settings
-from langchain_community.embeddings import OllamaEmbeddings
-from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings.ollama import OllamaEmbeddings
+from langchain_community.vectorstores.chroma import Chroma
 from langchain_core.documents import Document
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,20 +17,26 @@ config.Settings = Settings
 sys.modules['chromadb.config'] = config
 
 emb = types.ModuleType("langchain_community.embeddings")
+emb_ollama = types.ModuleType("langchain_community.embeddings.ollama")
 class OllamaEmbeddings:
     def __init__(self, *a, **k):
         pass
-emb.OllamaEmbeddings = OllamaEmbeddings
+emb_ollama.OllamaEmbeddings = OllamaEmbeddings
+emb.ollama = emb_ollama
 sys.modules['langchain_community.embeddings'] = emb
+sys.modules['langchain_community.embeddings.ollama'] = emb_ollama
 
 vecstores = types.ModuleType("langchain_community.vectorstores")
+vec_chroma = types.ModuleType("langchain_community.vectorstores.chroma")
 class Chroma:
     def __init__(self, *a, **k):
         pass
     def similarity_search(self, *a, **k):
         return []
-vecstores.Chroma = Chroma
+vec_chroma.Chroma = Chroma
+vecstores.chroma = vec_chroma
 sys.modules['langchain_community.vectorstores'] = vecstores
+sys.modules['langchain_community.vectorstores.chroma'] = vec_chroma
 
 langcore = types.ModuleType("langchain_core.documents")
 class Document:

--- a/tests/test_redraft.py
+++ b/tests/test_redraft.py
@@ -16,20 +16,26 @@ config.Settings = Settings
 sys.modules['chromadb.config'] = config
 
 emb = types.ModuleType("langchain_community.embeddings")
+emb_ollama = types.ModuleType("langchain_community.embeddings.ollama")
 class OllamaEmbeddings:
     def __init__(self, *a, **k):
         pass
-emb.OllamaEmbeddings = OllamaEmbeddings
+emb_ollama.OllamaEmbeddings = OllamaEmbeddings
+emb.ollama = emb_ollama
 sys.modules['langchain_community.embeddings'] = emb
+sys.modules['langchain_community.embeddings.ollama'] = emb_ollama
 
 vecstores = types.ModuleType("langchain_community.vectorstores")
+vec_chroma = types.ModuleType("langchain_community.vectorstores.chroma")
 class Chroma:
     def __init__(self, *a, **k):
         pass
     def similarity_search(self, *a, **k):
         return []
-vecstores.Chroma = Chroma
+vec_chroma.Chroma = Chroma
+vecstores.chroma = vec_chroma
 sys.modules['langchain_community.vectorstores'] = vecstores
+sys.modules['langchain_community.vectorstores.chroma'] = vec_chroma
 
 langcore = types.ModuleType("langchain_core.documents")
 class Document:

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -18,20 +18,26 @@ config.Settings = Settings
 sys.modules['chromadb.config'] = config
 
 emb = types.ModuleType("langchain_community.embeddings")
+emb_ollama = types.ModuleType("langchain_community.embeddings.ollama")
 class OllamaEmbeddings:
     def __init__(self, *a, **k):
         pass
-emb.OllamaEmbeddings = OllamaEmbeddings
+emb_ollama.OllamaEmbeddings = OllamaEmbeddings
+emb.ollama = emb_ollama
 sys.modules['langchain_community.embeddings'] = emb
+sys.modules['langchain_community.embeddings.ollama'] = emb_ollama
 
 vecstores = types.ModuleType("langchain_community.vectorstores")
+vec_chroma = types.ModuleType("langchain_community.vectorstores.chroma")
 class Chroma:
     def __init__(self, *a, **k):
         self._meta = []
     def get(self):
         return {"metadatas": self._meta}
-vecstores.Chroma = Chroma
+vec_chroma.Chroma = Chroma
+vecstores.chroma = vec_chroma
 sys.modules['langchain_community.vectorstores'] = vecstores
+sys.modules['langchain_community.vectorstores.chroma'] = vec_chroma
 
 langcore = types.ModuleType("langchain_core.documents")
 class Document:


### PR DESCRIPTION
## Summary
- import OllamaEmbeddings and Chroma from new submodules
- adjust unit test stubs for updated import paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a26a56d608329ace033a67785582a