### PR TITLE
Fix LangChain import paths in tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ class Settings:
 config.Settings = Settings
 sys.modules['chromadb.config'] = config
 
+langchain_community = types.ModuleType("langchain_community")
 emb = types.ModuleType("langchain_community.embeddings")
 emb_ollama = types.ModuleType("langchain_community.embeddings.ollama")
 class OllamaEmbeddings:
@@ -23,6 +24,8 @@ class OllamaEmbeddings:
         pass
 emb_ollama.OllamaEmbeddings = OllamaEmbeddings
 emb.ollama = emb_ollama
+langchain_community.embeddings = emb
+sys.modules['langchain_community'] = langchain_community
 sys.modules['langchain_community.embeddings'] = emb
 sys.modules['langchain_community.embeddings.ollama'] = emb_ollama
 
@@ -35,6 +38,7 @@ class Chroma:
         return []
 vec_chroma.Chroma = Chroma
 vecstores.chroma = vec_chroma
+langchain_community.vectorstores = vecstores
 sys.modules['langchain_community.vectorstores'] = vecstores
 sys.modules['langchain_community.vectorstores.chroma'] = vec_chroma
 

--- a/tests/test_redraft.py
+++ b/tests/test_redraft.py
@@ -15,6 +15,7 @@ class Settings:
 config.Settings = Settings
 sys.modules['chromadb.config'] = config
 
+langchain_community = types.ModuleType("langchain_community")
 emb = types.ModuleType("langchain_community.embeddings")
 emb_ollama = types.ModuleType("langchain_community.embeddings.ollama")
 class OllamaEmbeddings:
@@ -22,6 +23,8 @@ class OllamaEmbeddings:
         pass
 emb_ollama.OllamaEmbeddings = OllamaEmbeddings
 emb.ollama = emb_ollama
+langchain_community.embeddings = emb
+sys.modules['langchain_community'] = langchain_community
 sys.modules['langchain_community.embeddings'] = emb
 sys.modules['langchain_community.embeddings.ollama'] = emb_ollama
 
@@ -34,6 +37,7 @@ class Chroma:
         return []
 vec_chroma.Chroma = Chroma
 vecstores.chroma = vec_chroma
+langchain_community.vectorstores = vecstores
 sys.modules['langchain_community.vectorstores'] = vecstores
 sys.modules['langchain_community.vectorstores.chroma'] = vec_chroma
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -17,6 +17,7 @@ class Settings:
 config.Settings = Settings
 sys.modules['chromadb.config'] = config
 
+langchain_community = types.ModuleType("langchain_community")
 emb = types.ModuleType("langchain_community.embeddings")
 emb_ollama = types.ModuleType("langchain_community.embeddings.ollama")
 class OllamaEmbeddings:
@@ -24,6 +25,8 @@ class OllamaEmbeddings:
         pass
 emb_ollama.OllamaEmbeddings = OllamaEmbeddings
 emb.ollama = emb_ollama
+langchain_community.embeddings = emb
+sys.modules['langchain_community'] = langchain_community
 sys.modules['langchain_community.embeddings'] = emb
 sys.modules['langchain_community.embeddings.ollama'] = emb_ollama
 
@@ -36,6 +39,7 @@ class Chroma:
         return {"metadatas": self._meta}
 vec_chroma.Chroma = Chroma
 vecstores.chroma = vec_chroma
+langchain_community.vectorstores = vecstores
 sys.modules['langchain_community.vectorstores'] = vecstores
 sys.modules['langchain_community.vectorstores.chroma'] = vec_chroma
 


### PR DESCRIPTION
## Summary
- ensure `langchain_community` root module is stubbed in unit tests
- continue to import Ollama embeddings and Chroma from the recommended module paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a33bbe18c83298c71cded7c3eb252