### PR TITLE
Add boot indexing toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ docker compose up -d
 docker exec ollama ollama pull llama3:8b-instruct-q3_K_L
 ```
 
-Uploaded PDFs are indexed via the admin endpoints. To index existing files
-under `./data/persist`, run `python -m app.boot` inside the backend container.
-Ensure this directory exists and is writable so that admin uploads can be saved.
+Any PDFs placed under `./data/persist` are indexed automatically when the
+backend container starts. To run the process manually, execute
+`python -m app.boot` inside the container. Set `SKIP_BOOT_INDEXING=1` in the
+backend service if you want to skip this automatic indexing step. Ensure the
+`./data/persist` directory exists and is writable so that admin uploads can be
+saved.
 
 ### Air‑gap deployment
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,6 +36,7 @@ services:
       - RAG_SEARCH_TOP_K=10
       - RAG_USE_MMR=0
       - RAG_DYNAMIC_K_FACTOR=0
+      - SKIP_BOOT_INDEXING=0   # set to 1 to skip python -m app.boot on startup
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
     networks:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,12 +20,16 @@ done
 echo "✅ Ollama is up!"
 
 # ------------------------------------------------------------------
-# index PDFs (if any) before launching the app
+# optional boot indexing
 # ------------------------------------------------------------------
-# (errors are caught inside app/boot.py, so this always returns zero)
-#gosu llm python -m app.boot
-
-echo "📚  boot indexing skipped for testing, now starting Uvicorn"
+SKIP_BOOT_INDEXING="${SKIP_BOOT_INDEXING:-0}"
+if [ "$SKIP_BOOT_INDEXING" != "1" ]; then
+  echo "📚  running boot indexing"
+  # errors are caught inside app/boot.py, so this always returns zero
+  gosu llm python -m app.boot
+else
+  echo "📚  boot indexing skipped via SKIP_BOOT_INDEXING=1"
+fi
 
 # ------------------------------------------------------------------
 # drop privileges and launch Uvicorn


### PR DESCRIPTION
## Summary
- run `python -m app.boot` on container startup unless `SKIP_BOOT_INDEXING=1`
- note boot indexing behaviour in README
- expose `SKIP_BOOT_INDEXING` env var in compose file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a469509b48329b18fa782ce38e7a5