### PR TITLE
Pin Chromadb 0.5.23

### DIFF
--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -1,7 +1,7 @@
 fastapi
 uvicorn[standard]
 langchain-community
-chromadb==0.5.29
+chromadb==0.5.23
 pydantic>=2.0.0
 pydantic-core>=2.0.0
 pymupdf


### PR DESCRIPTION
## Summary
- pin `chromadb` to 0.5.23 in `docker/requirements.in`
- tried (and failed) to regenerate `requirements.lock` due to missing `pip-compile`

## Testing
- `pip-compile docker/requirements.in -o requirements.lock` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4bab34d08329b6bd98192321a6c2