### PR TITLE
Update offline deployment docs

### DIFF
--- a/docs/OFFLINE_DEPLOY.md
+++ b/docs/OFFLINE_DEPLOY.md
@@ -10,6 +10,20 @@ docker pull ollama/ollama:latest
 docker compose build
 ```
 
+After the build completes edit `compose.yaml` so the offline server uses the
+prebuilt images instead of trying to rebuild them. Replace each `build:` section
+with the matching `image:` tag:
+
+```yaml
+rag-app:
+  image: offlinellm-rag-app:latest
+  # ...
+
+frontend:
+  image: offline-llm-frontend:latest
+  # ...
+```
+
 ## 2 Save images & copy assets
 
 ```bash

--- a/docs/README-DEPLOY.md
+++ b/docs/README-DEPLOY.md
@@ -184,6 +184,10 @@ docker compose -f compose.yaml build --no-cache
 docker compose -f compose.yaml up -d
 ```
 
+If you built the images on another machine (for an offline install), edit
+`compose.yaml` and replace the `build:` sections with `image:` tags as shown in
+[OFFLINE_DEPLOY.md](OFFLINE_DEPLOY.md).
+
 ---
 
 ## 7. Verify

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -122,6 +122,11 @@ networks:
 
 ```
 
+If you loaded prebuilt images from `offline_stack.tar`, update `compose.yaml`
+and replace the `build:` entries for `rag-app` and `frontend` with `image:` tags
+(`offlinellm-rag-app:latest` and `offline-llm-frontend:latest`). See
+[OFFLINE_DEPLOY.md](OFFLINE_DEPLOY.md) for a snippet.
+
 ---
 
 ## Pulling & Running Ollama


### PR DESCRIPTION
## Summary
- show how to swap `build:` with `image:` in `compose.yaml` for offline installs
- link the new instructions in all deployment guides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7da6b9308329a56d687351509254