### PR TITLE
make uvicorn workers configurable

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,6 +38,7 @@ services:
       - RAG_DYNAMIC_K_FACTOR=0
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
+      - UVICORN_WORKERS=1
     networks:
       - rag-net
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,4 +30,5 @@ echo "📚  boot indexing skipped for testing, now starting Uvicorn"
 # ------------------------------------------------------------------
 # drop privileges and launch Uvicorn
 # ------------------------------------------------------------------
-exec gosu llm uvicorn app.api:app --host 0.0.0.0 --port 8000 --workers 1
+WORKERS=${UVICORN_WORKERS:-1}
+exec gosu llm uvicorn app.api:app --host 0.0.0.0 --port 8000 --workers "$WORKERS"

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -186,6 +186,7 @@ Use `VITE_API_URL=http://localhost:8000` while developing and keep
 | `SESSION_TTL_MIN` | `60` | delete idle sessions after *N* minutes |
 | `RAG_TOK_LIMIT` | `2000` | truncate history to this many tokens |
 | `CORS_ALLOW` | `""` | comma-separated allowed origins |
+| `UVICORN_WORKERS` | `1` | number of Uvicorn worker processes |
 ---
 
 ## 8 Updating dependencies
@@ -207,7 +208,7 @@ published `requirements.lock`.
 | Symptom | Fix |
 |---------|-----|
 | `winget` missing | install Git manually & ensure PATH |
-| **400 – model requires more memory** | keep using quantised tag (`q3_K_L`) or set uvicorn workers to **1** |
+| **400 – model requires more memory** | keep using quantised tag (`q3_K_L`) or set `UVICORN_WORKERS=1` |
 | *Container name conflict* | `docker compose down` or `docker rm -f $(docker ps -aq)` |
 | First chat call ≈ 40 s | model loading; subsequent calls ≈ 2 s |
 

--- a/docs/README-DEPLOY.md
+++ b/docs/README-DEPLOY.md
@@ -140,6 +140,7 @@ services:
       - RAG_DYNAMIC_K_FACTOR=0
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
+      - UVICORN_WORKERS=1
     networks:
       - rag-net
 

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -91,6 +91,7 @@ services:
       - RAG_DYNAMIC_K_FACTOR=0
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
+      - UVICORN_WORKERS=1
     networks:
       - rag-net
 


### PR DESCRIPTION
## Summary
- allow entrypoint to read `UVICORN_WORKERS`
- document the variable in DEV_SETUP.md
- add `UVICORN_WORKERS` to compose file and deployment docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c4e18a6988329873a55f0c25daceb