### PR TITLE
Update backend builder to use pip wheel

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -11,8 +11,8 @@ WORKDIR /build
 COPY requirements.lock .   
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential \
- && pip install --upgrade pip \
- && pip download --dest wheelhouse -r requirements.lock \
+ && pip install --upgrade pip wheel setuptools \
+ && pip wheel -w wheelhouse -r requirements.lock \
  && apt-get purge -y build-essential \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- switch to `pip wheel` for offline build and make sure pip, wheel, and setuptools are installed first

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c861d52f483298241fc7f10c4541e