### PR TITLE
Add CROSS_ENCODER_DIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ of **tokens** per extra retrieved chunk. For example:
 RAG_DYNAMIC_K_FACTOR=20  # adds one result for every 20 tokens
 ```
 
+
 The default is `0`, which disables this behavior entirely.
+
+## 🔧 Cross-encoder directory
+
+The re-ranking model is loaded from `/app/models/cross_encoder` by default.
+Set `CROSS_ENCODER_DIR` in the backend service to override this location.
 
 ---
 

--- a/app/rerank.py
+++ b/app/rerank.py
@@ -5,7 +5,7 @@ import os
 import logging
 from sentence_transformers import CrossEncoder
 
-MODEL_DIR = "/app/models/cross_encoder"
+MODEL_DIR = os.getenv("CROSS_ENCODER_DIR", "/app/models/cross_encoder")
 
 DEFAULT_TOP_K = int(os.getenv("RERANK_TOP_K", "3"))
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,7 @@ services:
       - CHUNK_SIZE=800
       - CHUNK_OVERLAP=100
       - RERANK_TOP_K=3
+      - CROSS_ENCODER_DIR=/app/models/cross_encoder
       - RAG_SEARCH_TOP_K=10
       - RAG_USE_MMR=0
       - RAG_DYNAMIC_K_FACTOR=0


### PR DESCRIPTION
## Summary
- make `rerank.py` read model path from `CROSS_ENCODER_DIR` env var
- document `CROSS_ENCODER_DIR` in README
- expose `CROSS_ENCODER_DIR` in compose.yaml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c89fa92a08329b57254e889d3ae18