### PR TITLE
Add SKIP_BOOT_INDEXING env control

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ docker exec ollama ollama pull llama3:8b-instruct-q3_K_L
 Uploaded PDFs are indexed via the admin endpoints. To index existing files
 under `./data/persist`, run `python -m app.boot` inside the backend container.
 Ensure this directory exists and is writable so that admin uploads can be saved.
+Set `SKIP_BOOT_INDEXING=1` in the backend service to skip this step at
+startup.
 
 ### Air‑gap deployment
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,9 +23,14 @@ echo "✅ Ollama is up!"
 # index PDFs (if any) before launching the app
 # ------------------------------------------------------------------
 # (errors are caught inside app/boot.py, so this always returns zero)
-#gosu llm python -m app.boot
+if [ "${SKIP_BOOT_INDEXING:-0}" = "0" ]; then
+  echo "📚  running boot indexing"
+  gosu llm python -m app.boot
+else
+  echo "📚  boot indexing skipped"
+fi
 
-echo "📚  boot indexing skipped for testing, now starting Uvicorn"
+echo "starting Uvicorn"
 
 # ------------------------------------------------------------------
 # drop privileges and launch Uvicorn

--- a/docs/OFFLINE_DEPLOY.md
+++ b/docs/OFFLINE_DEPLOY.md
@@ -91,6 +91,8 @@ docker exec ollama ollama list
 
 - Set the `ADMIN_PASSWORD` environment variable in `compose.yaml` before
   running `docker compose up -d` if you want to enable the admin endpoints.
+- Set `SKIP_BOOT_INDEXING=1` if you do **not** want PDFs under `./data/persist`
+  indexed automatically at startup.
 - PDFs placed under `./data/persist` are **not** indexed automatically.
   Upload via the admin API or run `python -m app.boot` inside the backend
   container to index them manually.

--- a/docs/README-DEPLOY.md
+++ b/docs/README-DEPLOY.md
@@ -140,6 +140,7 @@ services:
       - RAG_DYNAMIC_K_FACTOR=0
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
+      - SKIP_BOOT_INDEXING=1   # skip boot-time PDF indexing
       - UVICORN_WORKERS=1
     networks:
       - rag-net

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -91,6 +91,7 @@ services:
       - RAG_DYNAMIC_K_FACTOR=0
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
+      - SKIP_BOOT_INDEXING=1   # skip boot-time PDF indexing
       - UVICORN_WORKERS=1
     networks:
       - rag-net


### PR DESCRIPTION
## Summary
- allow optional boot indexing in entrypoint via `SKIP_BOOT_INDEXING`
- document `SKIP_BOOT_INDEXING` in README and deployment guides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c89fc6f3c83299712d397d47ea6a4