### PR TITLE
Fix chroma-hnswlib version in lock file

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -39,7 +39,7 @@ certifi==2025.6.15
     #   requests
 charset-normalizer==3.4.2
     # via requests
-chroma-hnswlib==0.7.6
+chroma-hnswlib==0.7.3
     # via chromadb
 chromadb==0.4.24
     # via -r docker/requirements.in


### PR DESCRIPTION
## Summary
- pin `chroma-hnswlib` to `0.7.3` in `requirements.lock`

## Testing
- `pytest -q`
- `pip-compile docker/requirements.in -o requirements.lock` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c90245430832985a6637fe930bf62