### PR TITLE
Fix Ruff lint imports

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,5 @@
+line-length = 88
+exclude = ["node_modules", "offline-llm-ui", "offline_llm_models"]
+[lint]
+select = ["E", "F"]
+ignore = ["E501"]

--- a/app/api.py
+++ b/app/api.py
@@ -14,11 +14,22 @@ from fastapi import FastAPI, File, HTTPException, Query, UploadFile, Depends
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import secrets
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from app import vector_store
-from app.speech import transcribe_audio
 from app import boot
+from app import vector_store
+from app.vector_store import (
+    SESSIONS_ROOT,
+    get_session_store,
+    new_session_store,
+    purge_session_store,
+    similarity_search,
+)
+from app.chat import chat as chat_fn, new_session_id, safe_chat
+from app.ingestion import load_and_split
+from app.ollama_utils import finalize_ollama_chat
+from app.rerank import rerank
+from app.speech import transcribe_audio
+from app.tokenizer import count_tokens
 
 # ───────────────────────── Environment / Ollama client ───────────────────────
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://ollama:11434")
@@ -141,18 +152,7 @@ async def ping():
     return PingResponse()
 
 # ───────────────────────── Session store & RAG helpers ────────────────────
-from app.ingestion      import load_and_split
-from app.vector_store   import (
-    SESSIONS_ROOT,
-    get_session_store,
-    new_session_store,
-    purge_session_store,
-    similarity_search,
-)
-from app.rerank         import rerank
-from app.chat           import chat as chat_fn, new_session_id, safe_chat
-from app.ollama_utils   import finalize_ollama_chat
-from app.tokenizer      import count_tokens
+
 
 _SESSIONS       : Dict[str, object]   = {}
 _SESSIONS_TOUCH : Dict[str, datetime] = {}

--- a/app/speech.py
+++ b/app/speech.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from typing import Optional
 
 try:
     import whisper

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 from pathlib import Path
 import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -120,8 +121,8 @@ ollama.chat = lambda *a, **k: {"message": {"content": "dummy"}}
 sys.modules['ollama'] = ollama
 
 # ---- import target module ----
-import app.api as api
-from fastapi.testclient import TestClient
+import app.api as api  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 class DummyDoc:
     def __init__(self, text):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -32,7 +33,7 @@ class DummyDoc:
 lc_schema_mod.Document = DummyDoc
 sys.modules['langchain.schema'] = lc_schema_mod
 
-import app.ingestion as ingestion
+import app.ingestion as ingestion  # noqa: E402
 
 
 def test_load_and_split(tmp_path):

--- a/tests/test_redraft.py
+++ b/tests/test_redraft.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -111,8 +112,8 @@ ollama.Client = lambda: None
 ollama.chat = lambda *a, **k: {"message": {"content": "dummy"}}
 sys.modules['ollama'] = ollama
 
-import app.api as api
-from fastapi.testclient import TestClient
+import app.api as api  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 
 def test_redraft_endpoint(monkeypatch):

--- a/tests/test_speech.py
+++ b/tests/test_speech.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,7 +11,7 @@ class DummyModel:
 whisper_mod.load_model = lambda name='base': DummyModel()
 sys.modules['whisper'] = whisper_mod
 
-import app.speech as speech
+import app.speech as speech  # noqa: E402
 speech.whisper = whisper_mod
 speech._MODEL = None
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,4 +1,5 @@
-import sys, types
+import sys
+import types
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -39,7 +40,7 @@ class Document:
 langcore.Document = Document
 sys.modules['langchain_core.documents'] = langcore
 
-import app.vector_store as vs
+import app.vector_store as vs  # noqa: E402
 
 class DummyStore:
     def __init__(self, metas):


### PR DESCRIPTION
## Summary
- create `.ruff.toml` for lint configuration
- clean up unused imports in `app` modules
- allow delayed imports in test modules
- update imports to avoid E401/E402

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c956de3788329822d66ae2e78d656