### PR TITLE
Remove obsolete langchain-ollama dependency

### DIFF
--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -26,7 +26,6 @@ pypdf==5.0.1
 
 # Ollama interface
 ollama==0.5.1
-langchain-ollama==0.3.5
 
 # File uploads
 python-multipart==0.0.9

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -81,7 +81,6 @@ pydantic==2.9.2
 pymupdf==1.24.10
 pypdf==5.0.1
 ollama==0.5.1
-langchain-ollama==0.3.5
 python-multipart==0.0.9
 ```
 </details>

--- a/requirements.lock
+++ b/requirements.lock
@@ -196,8 +196,6 @@ oauthlib==3.3.1
     #   requests-oauthlib
 ollama==0.5.1
     # via -r docker/requirements.in
-langchain-ollama==0.3.5
-    # via -r docker/requirements.in
 onnxruntime==1.18.1
     # via
     #   -r docker/requirements.in


### PR DESCRIPTION
## Summary
- remove `langchain-ollama` from backend deps
- update developer docs
- drop unused package from lock file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc6d0165883298c727bf337b6404e