### PR TITLE
Document boot indexing env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ docker exec ollama ollama pull llama3:8b-instruct-q3_K_L
 Uploaded PDFs are indexed via the admin endpoints. To index existing files
 under `./data/persist`, run `python -m app.boot` inside the backend container.
 Ensure this directory exists and is writable so that admin uploads can be saved.
-Set `SKIP_BOOT_INDEXING=1` in the backend service to skip this step at
-startup.
+Boot indexing runs by default (`SKIP_BOOT_INDEXING=0` in `compose.yaml`). Set
+`SKIP_BOOT_INDEXING=1` in the backend service to skip this step at startup.
 
 ### Air‑gap deployment
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,6 +39,7 @@ services:
       - RAG_DYNAMIC_K_FACTOR=0
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
+      - SKIP_BOOT_INDEXING=0   # set to 1 to skip boot-time indexing
       - UVICORN_WORKERS=3
     networks:
       - rag-net


### PR DESCRIPTION
## Summary
- add `SKIP_BOOT_INDEXING=0` to compose.yaml so the default is explicit
- document the default in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdf8dd6088329b31d0651c12ef9b3