### PR TITLE
add docs & compose var for default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ docker compose up -d
 docker exec ollama ollama pull llama3:8b-instruct-q3_K_L
 ```
 
+The backend uses this model as its default. If it isn't pulled (or if you set
+`OLLAMA_DEFAULT_MODEL` to something else), `/chat` will return **500 Internal
+Server Error** and the frontend dropdown will be empty. Adjust the model via
+`compose.yaml` or pull it ahead of time.
+
 Uploaded PDFs are indexed via the admin endpoints. To index existing files
 under `./data/persist`, run `python -m app.boot` inside the backend container.
 Ensure this directory exists and is writable so that admin uploads can be saved.

--- a/app/chat.py
+++ b/app/chat.py
@@ -30,7 +30,7 @@ SYSTEM_PROMPTS: Dict[str, str] = {
 # configuration
 # ------------------------------------------------------------------
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")
-DEFAULT_MODEL    = "llama3:8b-instruct-q3_K_L"
+DEFAULT_MODEL    = os.getenv("OLLAMA_DEFAULT_MODEL", "llama3:8b-instruct-q3_K_L")
 
 # in-memory map session_id → ConversationBufferMemory
 _sessions: Dict[str, ConversationBufferMemory] = {}

--- a/compose.yaml
+++ b/compose.yaml
@@ -37,6 +37,7 @@ services:
       - RAG_SEARCH_TOP_K=10
       - RAG_USE_MMR=0
       - RAG_DYNAMIC_K_FACTOR=0
+      - OLLAMA_DEFAULT_MODEL=llama3:8b-instruct-q3_K_L
       - PERSIST_CHROMA_DIR=/app/data/chroma_persist
       - ADMIN_PASSWORD=changeme
       - SKIP_BOOT_INDEXING=1   # set to 1 to skip boot-time indexing

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -181,7 +181,7 @@ Use `VITE_API_URL=http://localhost:8000` while developing and keep
 | `PERSIST_CHROMA_DIR` | `data/chroma_persist` | permanent embeddings |
 | `SESSION_CHROMA_DIR` | `data/chroma_sessions` | per-chat embeddings |
 | `ADMIN_PASSWORD` | `None` | protects `/admin/*` endpoints |
-| `OLLAMA_DEFAULT_MODEL` | `llama3:8b-instruct-q3_K_L` | default chat model |
+| `OLLAMA_DEFAULT_MODEL` | `llama3:8b-instruct-q3_K_L` | default chat model (must be pulled or changed) |
 | `SYSTEM_PROMPT` | `You are a helpful assistant.` | system prompt sent on first turn |
 | `SESSION_TTL_MIN` | `60` | delete idle sessions after *N* minutes |
 | `RAG_TOK_LIMIT` | `2000` | truncate history to this many tokens |

--- a/docs/OFFLINE_DEPLOY.md
+++ b/docs/OFFLINE_DEPLOY.md
@@ -15,6 +15,10 @@ ollama pull llama3:8b-instruct-q3_K_L
 ollama pull nomic-embed-text
 ```
 
+`compose.yaml` uses `llama3:8b-instruct-q3_K_L` as the default chat model. Make
+sure it is pulled (or change `OLLAMA_DEFAULT_MODEL`) before running the full
+stack.
+
 After the build completes edit `compose.yaml` so the offline server uses the
 prebuilt images instead of trying to rebuild them. Replace each `build:` section
 with the matching `image:` tag:

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -167,6 +167,10 @@ docker exec -it ollama bash -lc "ollama pull nomic-embed-text && ollama pull lla
 docker exec -it ollama bash -lc "ollama list"
 ```
 
+`compose.yaml` sets `OLLAMA_DEFAULT_MODEL=llama3:8b-instruct-q3_K_L`. This model
+must exist locally or `/chat` requests will fail with `500` and the UI dropdown
+will be empty. Either pull it or change the variable to one you have.
+
 Missing models will lead to empty embeddings and indexing failures during ingestion.
 
 ---


### PR DESCRIPTION
## Summary
- make the default chat model configurable via `compose.yaml`
- read `OLLAMA_DEFAULT_MODEL` in `app/chat.py`
- document the need to pull the model or set the variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d210e36b08329aa7568fcaaf230ed