### PR TITLE
Clarify cross-encoder visibility

### DIFF
--- a/docs/OFFLINE_DEPLOY.md
+++ b/docs/OFFLINE_DEPLOY.md
@@ -91,6 +91,11 @@ docker compose up --no-build
 docker exec ollama ollama list
 ```
 
+The re-ranking **cross-encoder** model is stored under
+`offline_llm_models/cross_encoder` and mounted directly into the
+`rag-app` container. It will **not** appear in `ollama list` – the command
+only shows LLM weights managed by Ollama.
+
 ## 5 Notes
 
 - Set the `ADMIN_PASSWORD` environment variable in `compose.yaml` before

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -167,6 +167,11 @@ docker exec -it ollama bash -lc "ollama pull nomic-embed-text && ollama pull lla
 docker exec -it ollama bash -lc "ollama list"
 ```
 
+Only LLM weights managed by **Ollama** show up in the list above. The
+cross-encoder used for re-ranking lives in the
+`offline_llm_models/cross_encoder` directory and mounts directly into the
+`rag-app` container, so you won’t see it in `ollama list`.
+
 `compose.yaml` sets `OLLAMA_DEFAULT_MODEL=llama3:8b-instruct-q3_K_L`. This model
 must exist locally or `/chat` requests will fail with `500` and the UI dropdown
 will be empty. Either pull it or change the variable to one you have.


### PR DESCRIPTION
## Summary
- note that the cross-encoder lives in `offline_llm_models/cross_encoder`
- mention that it will not show up in `ollama list`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2aa85cdc8329901474d784a50501