### PR TITLE
Handle ollama connection failure

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -113,13 +113,14 @@ class ModelInfo(BaseModel):
 async def list_models():
     """
     List all locally-pulled Ollama models.
-    Returns [] if the daemon isn’t ready yet.
+
+    Raises 503 if the Ollama daemon isn't reachable.
     """
     try:
         raw = client.list()
     except Exception as exc:
-        log.warning("ollama.list failed: %s", exc)
-        return []
+        log.error("ollama.list failed: %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc))
 
     out: List[ModelInfo] = []
     seen = set()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import asyncio
 import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -171,6 +172,18 @@ def test_parse_dynamic_k_factor(val, expected, raises):
             api._parse_dynamic_k_factor(val)
     else:
         assert api._parse_dynamic_k_factor(val) == expected
+
+
+def test_list_models_connection_error(monkeypatch):
+    class BadClient:
+        def list(self):
+            raise ConnectionError("boom")
+
+    monkeypatch.setattr(api, "client", BadClient())
+
+    with pytest.raises(api.HTTPException) as exc:
+        asyncio.get_event_loop().run_until_complete(api.list_models())
+    assert exc.value.status_code == 503
 
 
 


### PR DESCRIPTION
## Summary
- raise 503 when `/models` can't reach the Ollama daemon
- test the new `/models` failure branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6c5a90348329b5ad9a0f84a751c7