### PR TITLE
Add GPU selection for cross encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ The default is `0`, which disables this behavior entirely.
 The re-ranking model is loaded from `/app/models/cross_encoder` by default.
 Set `CROSS_ENCODER_DIR` in the backend service to override this location.
 
+### Device selection
+
+By default the cross-encoder runs on the CPU. Set `CROSS_ENCODER_DEVICE` to
+`cuda` or another device string to enable GPU acceleration when available.
+
 ---
 
 ## 📚 Docs

--- a/app/rerank.py
+++ b/app/rerank.py
@@ -6,6 +6,7 @@ import logging
 from sentence_transformers import CrossEncoder
 
 MODEL_DIR = os.getenv("CROSS_ENCODER_DIR", "/app/models/cross_encoder")
+DEVICE = os.getenv("CROSS_ENCODER_DEVICE", "cpu")
 
 DEFAULT_TOP_K = int(os.getenv("RERANK_TOP_K", "3"))
 
@@ -15,7 +16,8 @@ DEFAULT_TOP_K = int(os.getenv("RERANK_TOP_K", "3"))
 def _cross() -> CrossEncoder:
     """Return a cached cross-encoder instance."""
     try:
-        return CrossEncoder(MODEL_DIR, device="cpu", local_files_only=True)
+        logging.info("Loading cross-encoder from %s on %s", MODEL_DIR, DEVICE)
+        return CrossEncoder(MODEL_DIR, device=DEVICE, local_files_only=True)
     except OSError as exc:
         logging.warning("Cross-encoder model missing at %s: %s", MODEL_DIR, exc)
         raise RuntimeError(f"cross-encoder model not found in {MODEL_DIR}") from exc

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,7 @@ services:
       - CHUNK_OVERLAP=100
       - RERANK_TOP_K=3
       - CROSS_ENCODER_DIR=/app/models/cross_encoder
+      - CROSS_ENCODER_DEVICE=${CROSS_ENCODER_DEVICE:-cpu}
       - RAG_SEARCH_TOP_K=10
       - RAG_USE_MMR=0
       - RAG_DYNAMIC_K_FACTOR=0


### PR DESCRIPTION
## Summary
- make cross-encoder device configurable with `CROSS_ENCODER_DEVICE`
- pass this option via `compose.yaml`
- document device selection in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880cb6805908329aead3844efa4fbb0