### PR TITLE
Document /api/models endpoint usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 - **FastAPI backend** – ASGI‑native, easy to scale with multiple workers.
 - **Modular codebase** – Clear separation: `ingestion.py`, `vector_store.py`, `rerank.py`, `chat.py`, `api.py`.
 - **Cross‑platform** – Develop on Windows 11, deploy on Linux server or WSL2.
-- **Model listing** – `/models` enumerates available local LLMs.
+- **Model listing** – Backend exposes `/models` to enumerate local LLMs (served
+  as `/api/models` when routed through Nginx).
 - **Session‑based uploads + QA** – Upload a PDF via `/upload_pdf`, then query it with `/session_qa`.
 - **Dynamic retrieval** – Number of retrieved chunks scales with question length (token based).
 - **Offline speech-to-text** – Upload audio to `/speech_to_text` using OpenAI Whisper.
@@ -67,6 +68,14 @@ Open in browser:
 
 * <http://127.0.0.1:8000/ping>
 * <http://127.0.0.1:8000/docs>
+
+List available models:
+
+```bash
+curl http://localhost:8000/models
+# via HTTPS proxy
+curl -k https://localhost/api/models
+```
 
 ---
 

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -158,6 +158,13 @@ curl.exe http://localhost:11434/api/ping
 Invoke-RestMethod http://localhost:8000/ping
 ```
 
+List available models (`/models` directly or `/api/models` via Nginx):
+
+```powershell
+curl http://localhost:8000/models
+curl -k https://localhost/api/models
+```
+
 ---
 
 ## Pulling Models in Ollama
@@ -185,11 +192,14 @@ Missing models will lead to empty embeddings and indexing failures during ingest
 | Endpoint        | Method | Description                                  |
 |-----------------|--------|----------------------------------------------|
 | `/ping`         | GET    | Health check                                 |
+| `/models`       | GET    | List available local LLMs                    |
 | `/chat`         | POST   | Stateful chat w/ session memory              |
 | `/doc_qa`       | POST   | RAG over permanent KB (+ optional session)   |
 | `/upload_pdf`   | POST   | Ingest PDF into ephemeral session store      |
 | `/session/{id}` | DELETE | Purge session store                          |
 | `/session_qa`   | POST   | RAG over ephemeral + persistent KB           |
+
+The frontend container proxies these endpoints under `/api`, e.g. `/api/models`.
 
 ---
 


### PR DESCRIPTION
## Summary
- note nginx prefix for model listing in README
- show how to hit the endpoint with curl in README
- add `/models` row to API table in troubleshooting docs
- document `/api/models` proxy usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880f3a9ae508329b29c2175b3d5b50f