### PR TITLE
Fix frontend tag docs

### DIFF
--- a/docs/OFFLINE_DEPLOY.md
+++ b/docs/OFFLINE_DEPLOY.md
@@ -29,7 +29,7 @@ rag-app:
   # ...
 
 frontend:
-  image: offline-llm-frontend:latest
+  image: offlinellm-frontend:latest
   # ...
 ```
 
@@ -39,7 +39,7 @@ frontend:
 docker save -o offline_stack.tar \
   ollama/ollama:latest \
   offlinellm-rag-app:latest \
-  offline-llm-frontend:latest
+  offlinellm-frontend:latest
 
 # export pulled Ollama models
 docker run --rm -v ollama_models:/models -v $PWD:/backup \
@@ -78,7 +78,7 @@ services:
   rag-app:
     image: offlinellm-rag-app:latest
   frontend:
-    image: offline-llm-frontend:latest
+    image: offlinellm-frontend:latest
 ```
 
 ```bash

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -126,7 +126,7 @@ networks:
 
 If you loaded prebuilt images from `offline_stack.tar`, update `compose.yaml`
 and replace the `build:` entries for `rag-app` and `frontend` with `image:` tags
-(`offlinellm-rag-app:latest` and `offline-llm-frontend:latest`). See
+(`offlinellm-rag-app:latest` and `offlinellm-frontend:latest`). See
 [OFFLINE_DEPLOY.md](OFFLINE_DEPLOY.md) for a snippet.
 
 ---


### PR DESCRIPTION
## Summary
- update compose snippet in OFFLINE_DEPLOY.md
- update docker save example in OFFLINE_DEPLOY.md
- sync SETUP_AND_TROUBLESHOOTING_GUIDE.md with new frontend tag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880f82c68e0832995840905a2e62333