### PR TITLE
Expose models from backend

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, File, HTTPException, Query, UploadFile, Depends
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import secrets
 from fastapi.middleware.cors import CORSMiddleware
+from app.routes.models import router as models_router
 from pydantic import BaseModel
 from app import boot
 from app import vector_store
@@ -90,6 +91,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.include_router(models_router)
 
 def _verify_admin(creds: HTTPBasicCredentials = Depends(security)) -> None:
     """Simple HTTP Basic password check."""

--- a/app/routes/models.py
+++ b/app/routes/models.py
@@ -1,0 +1,14 @@
+import httpx
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+@router.get("/api/models")
+async def list_models():
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            r = await client.get("http://ollama:11434/api/tags")
+        r.raise_for_status()
+        return r.json()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -92,6 +92,130 @@ sub.parse_options_header = parse_options_header
 sys.modules['multipart'] = mp
 sys.modules['multipart.multipart'] = sub
 
+# stub httpx.AsyncClient used in app.routes.models
+httpx_mod = types.ModuleType('httpx')
+
+class AsyncClient:
+    def __init__(self, *a, **k):
+        pass
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url):
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {}
+        return R()
+
+httpx_mod.AsyncClient = AsyncClient
+sys.modules['httpx'] = httpx_mod
+
+# minimal pydantic BaseModel stub
+pydantic_mod = types.ModuleType('pydantic')
+class BaseModel:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+    def dict(self):
+        def conv(val):
+            if isinstance(val, BaseModel):
+                return val.dict()
+            if isinstance(val, list):
+                return [conv(v) for v in val]
+            if isinstance(val, dict):
+                return {k: conv(v) for k, v in val.items()}
+            return val
+        return {k: conv(v) for k, v in self.__dict__.items()}
+    model_dump = dict
+pydantic_mod.BaseModel = BaseModel
+sys.modules['pydantic'] = pydantic_mod
+
+# Minimal fastapi stubs to allow importing app.api without the real library
+fastapi_stub = types.ModuleType('fastapi')
+
+class FastAPI:
+    def __init__(self, *a, **k):
+        pass
+    def add_middleware(self, *a, **k):
+        pass
+    def include_router(self, *a, **k):
+        pass
+    def on_event(self, *a, **k):
+        def decorator(fn):
+            return fn
+        return decorator
+    def get(self, *a, **k):
+        def decorator(fn):
+            return fn
+        return decorator
+    def post(self, *a, **k):
+        def decorator(fn):
+            return fn
+        return decorator
+    def delete(self, *a, **k):
+        def decorator(fn):
+            return fn
+        return decorator
+
+def File(*a, **k):
+    return None
+
+class HTTPException(Exception):
+    def __init__(self, status_code: int, detail: str | None = None, headers=None):
+        self.status_code = status_code
+        self.detail = detail
+        self.headers = headers
+
+class Query:
+    def __init__(self, default=None, description: str | None = None):
+        self.default = default
+        self.description = description
+
+class UploadFile:
+    def __init__(self, filename: str = ''):
+        self.filename = filename
+        self.file = types.SimpleNamespace(close=lambda: None)
+
+class Depends:
+    def __init__(self, dependency):
+        self.dependency = dependency
+
+class APIRouter:
+    def get(self, *a, **k):
+        def decorator(fn):
+            return fn
+        return decorator
+
+class HTTPBasic:
+    pass
+
+class HTTPBasicCredentials:
+    def __init__(self, username: str = '', password: str = ''):
+        self.username = username
+        self.password = password
+
+class CORSMiddleware:
+    pass
+
+fastapi_stub.FastAPI = FastAPI
+fastapi_stub.File = File
+fastapi_stub.HTTPException = HTTPException
+fastapi_stub.Query = Query
+fastapi_stub.UploadFile = UploadFile
+fastapi_stub.Depends = Depends
+fastapi_stub.APIRouter = APIRouter
+cors_mod = types.ModuleType('fastapi.middleware.cors')
+cors_mod.CORSMiddleware = CORSMiddleware
+security_mod = types.ModuleType('fastapi.security')
+security_mod.HTTPBasic = HTTPBasic
+security_mod.HTTPBasicCredentials = HTTPBasicCredentials
+sys.modules['fastapi'] = fastapi_stub
+sys.modules['fastapi.middleware.cors'] = cors_mod
+sys.modules['fastapi.security'] = security_mod
+
 # Provide a fake fastapi TestClient that calls the endpoint function directly
 tc_mod = types.ModuleType('fastapi.testclient')
 class FakeResponse:


### PR DESCRIPTION
## Summary
- add new router `app/routes/models.py` that proxies to Ollama's `/api/tags`
- register router in `app/api.py`
- adjust tests to run without FastAPI or httpx by providing stub modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810581597083298045a16bbb83392a