### PR TITLE
Fix model listing and offline workflow

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 services:
   ollama:
     image: ollama/ollama:latest
+    pull_policy: never
     container_name: ollama
     ports:
       - "11434:11434"
@@ -12,9 +13,8 @@ services:
           - ollama
 
   rag-app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.backend
+    image: offlinellm-rag-app:latest
+    pull_policy: never
     container_name: rag-app
     depends_on:
       - ollama
@@ -47,11 +47,8 @@ services:
       - rag-net
 
   frontend:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.frontend
-      args:
-        - VITE_API_URL=/api
+    image: offlinellm-frontend:latest
+    pull_policy: never
     environment:
       - VITE_API_URL=/api   # runtime fallback
     container_name: offline-llm-frontend

--- a/deploy_offline.ps1
+++ b/deploy_offline.ps1
@@ -1,0 +1,12 @@
+# Deploy OfflineLLM on a machine without internet access
+
+# Load prebuilt images
+docker load -i .\offline_stack.tar
+
+# Restore Ollama models volume
+docker volume create ollama_models
+docker run --rm -v ollama_models:/models -v $PWD:/backup `
+    busybox tar xf /backup/ollama_models.tar -C / --strip-components=1
+
+# Start the stack without pulling or building
+docker compose up -d --pull never --no-build

--- a/offline-llm-ui/src/api/index.ts
+++ b/offline-llm-ui/src/api/index.ts
@@ -42,7 +42,9 @@ export interface AdminUploadResponse {
 export async function listModels(): Promise<ModelInfo[]> {
   const res = await fetch(`${BASE}/models`)
   if (!res.ok) throw new Error(`listModels failed: ${res.statusText}`)
-  return (await res.json()) as ModelInfo[]
+  const data = await res.json()
+  const models = Array.isArray(data) ? data : data.models ?? []
+  return models as ModelInfo[]
 }
 
 /**

--- a/save_stack.ps1
+++ b/save_stack.ps1
@@ -1,0 +1,16 @@
+# Build and export OfflineLLM images on an online machine
+
+# Pull base images and build the stack
+docker pull ollama/ollama:latest
+# build backend and frontend
+docker compose build
+
+# Save all images to a single archive
+docker save -o offline_stack.tar `
+    ollama/ollama:latest `
+    offlinellm-rag-app:latest `
+    offlinellm-frontend:latest
+
+# Archive pulled Ollama models
+docker run --rm -v ollama_models:/models -v $PWD:/backup `
+    busybox tar cf /backup/ollama_models.tar /models

--- a/tests/test_models_route.py
+++ b/tests/test_models_route.py
@@ -1,0 +1,33 @@
+import sys
+import types
+from pathlib import Path
+import asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# stub httpx.AsyncClient
+httpx_mod = types.ModuleType("httpx")
+class AsyncClient:
+    def __init__(self, *a, **k):
+        pass
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url):
+        assert url == "http://ollama:11434/api/tags"
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"models": [{"name": "a"}]}
+        return R()
+httpx_mod.AsyncClient = AsyncClient
+sys.modules['httpx'] = httpx_mod
+
+import app.routes.models as models  # noqa: E402
+models.httpx = httpx_mod
+
+def test_list_models_route():
+    res = asyncio.get_event_loop().run_until_complete(models.list_models())
+    assert res == {"models": [{"name": "a"}]}


### PR DESCRIPTION
## Summary
- handle both array/object responses for model listing
- prevent Compose from pulling/building images when offline
- add PowerShell scripts to export and deploy the stack
- add regression test for `/api/models` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810e0690948329a01b3cdef776d356