### PR TITLE
Update offline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ Boot indexing runs by default (`SKIP_BOOT_INDEXING=0` in `compose.yaml`). Set
 ### Air‑gap deployment
 
 See **docs/OFFLINE_DEPLOY.md** for the full offline workflow. In short,
-build/pull the images on a machine with internet access, export them to a
-`offline_stack.tar` archive along with the `offline_llm_models/` and `data/`
-directories, then load the archive on the server and run `docker compose up -d`.
+run `./save_stack.ps1` on a machine with internet access to build and export
+`offline_stack.tar` and `ollama_models.tar` along with the `offline_llm_models/`
+and `data/` directories. Copy them over and run `./deploy_offline.ps1` on the
+server to load everything and start the stack.
 ## 🔒 Admin mode
 
 Set an `ADMIN_PASSWORD` environment variable in the backend service. When defined, requests to any `/admin/*` endpoint must authenticate using HTTP Basic credentials with the `admin` username.

--- a/docs/OFFLINE_DEPLOY.md
+++ b/docs/OFFLINE_DEPLOY.md
@@ -4,34 +4,16 @@ This guide walks through preparing the Docker images on a machine with internet 
 
 ## 1 Build images online
 
-```bash
-docker pull ollama/ollama:latest
-# build backend and frontend images
-docker compose build
+Run the helper script to pull the base images, build the stack and export the
+tar archives:
 
-# start Ollama so models can be pulled
-docker compose up -d ollama
-ollama pull llama3:8b-instruct-q3_K_L
-ollama pull nomic-embed-text
+```bash
+./save_stack.ps1
 ```
 
 `compose.yaml` uses `llama3:8b-instruct-q3_K_L` as the default chat model. Make
 sure it is pulled (or change `OLLAMA_DEFAULT_MODEL`) before running the full
 stack.
-
-After the build completes edit `compose.yaml` so the offline server uses the
-prebuilt images instead of trying to rebuild them. Replace each `build:` section
-with the matching `image:` tag:
-
-```yaml
-rag-app:
-  image: offlinellm-rag-app:latest
-  # ...
-
-frontend:
-  image: offlinellm-frontend:latest
-  # ...
-```
 
 ## 2 Save images & copy assets
 
@@ -67,22 +49,6 @@ docker volume create ollama_models
 docker run --rm -v ollama_models:/models -v $PWD:/backup busybox tar xf \
   /backup/ollama_models.tar -C /
 docker compose up -d
-```
-
-### Use pre-built images
-
-`compose.yaml` contains `build:` directives for the backend and frontend. On an offline machine you can skip rebuilding them by changing those entries to use the pre-built images or by running `docker compose up --no-build`.
-
-```yaml
-services:
-  rag-app:
-    image: offlinellm-rag-app:latest
-  frontend:
-    image: offlinellm-frontend:latest
-```
-
-```bash
-docker compose up --no-build
 ```
 
 ## 4 Verify models

--- a/docs/OFFLINE_DEPLOY_WINDOWS_DUMMIES.md
+++ b/docs/OFFLINE_DEPLOY_WINDOWS_DUMMIES.md
@@ -12,21 +12,11 @@ This guide explains how to deploy **OfflineLLM** on a Windows Server machine wit
    git clone https://github.com/your-org/OfflineLLM.git
    cd OfflineLLM
    ```
-3. Build all Docker images and pull models:
+3. Run the helper script to build the images and archive everything for transfer:
    ```powershell
-   docker compose build
-   docker compose up -d ollama
-   ollama pull llama3:8b-instruct-q3_K_L
-   ollama pull nomic-embed-text
-   docker compose down
+   .\save_stack.ps1
    ```
-4. Save the images and models for transfer:
-   ```powershell
-   docker save ollama/ollama:latest offlinellm-rag-app:latest offlinellm-frontend:latest -o offline_stack.tar
-
-   docker run --rm -v ollama_models:/models -v ${PWD}:/backup busybox tar cf /backup/ollama_models.tar /models
-   ```
-5. Copy these items to your offline server:
+4. Copy these items to your offline server:
    - `compose.yaml`
    - the `certs/` directory
    - the `offline_llm_models` folder
@@ -68,16 +58,11 @@ This imports the Docker images and the pulled Ollama models.
 
 ---
 
-## 4. Adjust `compose.yaml`
+## 4. `compose.yaml`
 
-In the `compose.yaml` file replace each `build:` section with the prebuilt image names:
-```yaml
-rag-app:
-  image: offlinellm-rag-app:latest
-frontend:
-  image: offlinellm-frontend:latest
-```
-This avoids rebuilding images on the offline server.
+The provided `compose.yaml` already references the prebuilt images and sets
+`pull_policy: never` so Docker won't attempt to pull anything. No edits are
+required.
 
 ---
 

--- a/docs/README-DEPLOY.md
+++ b/docs/README-DEPLOY.md
@@ -114,9 +114,8 @@ services:
           - ollama
 
   rag-app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.backend
+    image: offlinellm-rag-app:latest
+    pull_policy: never
     container_name: rag-app
     depends_on:
       - ollama
@@ -146,11 +145,8 @@ services:
       - rag-net
 
   frontend:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.frontend
-      args:
-        - VITE_API_URL=/api
+    image: offlinellm-frontend:latest
+    pull_policy: never
     environment:
       - VITE_API_URL=/api   # runtime fallback
     container_name: offline-llm-frontend
@@ -186,9 +182,9 @@ docker compose -f compose.yaml build --no-cache
 docker compose -f compose.yaml up -d
 ```
 
-If you built the images on another machine (for an offline install), edit
-`compose.yaml` and replace the `build:` sections with `image:` tags as shown in
-[OFFLINE_DEPLOY.md](OFFLINE_DEPLOY.md).
+If you built the images on another machine, simply copy `offline_stack.tar` and
+`ollama_models.tar` along with the `data` and `offline_llm_models` directories.
+`compose.yaml` already references the prebuilt images so no edits are required.
 
 ---
 

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -124,10 +124,9 @@ networks:
 
 ```
 
-If you loaded prebuilt images from `offline_stack.tar`, update `compose.yaml`
-and replace the `build:` entries for `rag-app` and `frontend` with `image:` tags
-(`offlinellm-rag-app:latest` and `offlinellm-frontend:latest`). See
-[OFFLINE_DEPLOY.md](OFFLINE_DEPLOY.md) for a snippet.
+If you loaded prebuilt images from `offline_stack.tar` nothing needs to be
+edited—the provided `compose.yaml` already references the images and sets
+`pull_policy: never` so Docker won't try to pull them.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify offline deployment for Windows dummies
- update generic offline deployment docs
- refresh README deployment notes
- mention new save/deploy scripts and prebuilt compose setup
- remove outdated advice about editing compose.yaml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810fc2551883299d80a3334d7c5dfc