### PR TITLE
Fix parseThink to handle missing <think> blocks

### DIFF
--- a/offline-llm-ui/src/components/AssistantBubble/AssistantBubble.tsx
+++ b/offline-llm-ui/src/components/AssistantBubble/AssistantBubble.tsx
@@ -12,19 +12,19 @@ import ReactMarkdown from "react-markdown";
 import { parseThink } from "../../utils/parseThink";
 
 interface Props {
-  text: string;
+  text: unknown;
   color: string;
 }
 
 export function AssistantBubble({ text, color }: Props) {
-  const { answer, think } = parseThink(text);
+  const { visible, think } = parseThink(text);
   const [show, setShow] = useState(false);
   const [copied, setCopied] = useState(false);
   const gray = useColorModeValue("gray.600", "gray.400");
 
   const onCopy = async () => {
     try {
-      await navigator.clipboard.writeText(answer);
+      await navigator.clipboard.writeText(visible);
       setCopied(true);
       setTimeout(() => setCopied(false), 1000);
     } catch {
@@ -91,7 +91,7 @@ export function AssistantBubble({ text, color }: Props) {
           </Collapse>
         </>
       )}
-      <ReactMarkdown>{answer}</ReactMarkdown>
+      <ReactMarkdown>{visible}</ReactMarkdown>
     </Box>
   );
 }

--- a/offline-llm-ui/src/utils/parseThink.ts
+++ b/offline-llm-ui/src/utils/parseThink.ts
@@ -1,15 +1,31 @@
-export interface ThinkParseResult {
-  answer: string;
-  think?: string;
+export interface ParsedMsg {
+  visible: string;
+  think: string;
 }
 
-export function parseThink(text: string): ThinkParseResult {
+/**
+ * Extracts optional <think> blocks from model output. The raw input may be a
+ * string, array of strings (streaming deltas) or anything with a toString
+ * method. All text outside the tags is returned in `visible` while the inner
+ * text of the first <think>...</think> pair is returned as `think`.
+ */
+export function parseThink(raw: unknown): ParsedMsg {
+  // Normalise to a single string while being null/undefined safe
+  const text =
+    typeof raw === 'string'
+      ? raw
+      : Array.isArray(raw)
+      ? raw.join('')
+      : raw?.toString?.() ?? '';
+
   const match = text.match(/<think>([\s\S]*?)<\/think>/i);
-  if (match) {
-    return {
-      answer: text.replace(match[0], '').trimStart(),
-      think: match[1].trim(),
-    };
+
+  if (!match) {
+    return { visible: text.trim(), think: '' };
   }
-  return { answer: text };
+
+  const think = match[1]?.trim() ?? '';
+  const visible = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+  return { visible, think };
 }


### PR DESCRIPTION
## Summary
- improve parseThink to safely handle non-string responses and missing `<think>` tags
- adjust AssistantBubble to use new parseThink interface

## Testing
- `pytest -q`
- `npm run build` *(fails: Could not find a declaration file for module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_688126a643f88329911149e83076edf1