### PR TITLE
Improve warmup handling for /api/chat

### DIFF
--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -1,14 +1,18 @@
 from fastapi import APIRouter, HTTPException
-import httpx
+
+from app.chat import safe_chat
 
 router = APIRouter()
 
 @router.post("/api/chat")
 async def chat(payload: dict):
     try:
-        async with httpx.AsyncClient(timeout=120) as client:
-            r = await client.post("http://ollama:11434/api/chat", json=payload)
-        r.raise_for_status()
-        return r.json()
+        model = payload.get("model")
+        messages = payload.get("messages")
+        if not isinstance(messages, list):
+            raise ValueError("messages must be a list")
+
+        kwargs = {k: v for k, v in payload.items() if k not in {"model", "messages"}}
+        return safe_chat(model=model, messages=messages, stream=False, **kwargs)
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))


### PR DESCRIPTION
## Summary
- handle model load warmup in the `/api/chat` proxy

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812fadbaac8329959ace82dfaed55c