### PR TITLE
Handle /api/chat fallback

### DIFF
--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 
-from app.chat import safe_chat
+from app.chat import safe_chat, chat as chat_fn, new_session_id
 
 router = APIRouter()
 
@@ -9,10 +9,18 @@ async def chat(payload: dict):
     try:
         model = payload.get("model")
         messages = payload.get("messages")
-        if not isinstance(messages, list):
-            raise ValueError("messages must be a list")
 
-        kwargs = {k: v for k, v in payload.items() if k not in {"model", "messages"}}
-        return safe_chat(model=model, messages=messages, stream=False, **kwargs)
+        if isinstance(messages, list):
+            kwargs = {k: v for k, v in payload.items() if k not in {"model", "messages"}}
+            return safe_chat(model=model, messages=messages, stream=False, **kwargs)
+
+        # fallback: behave like /chat for compatibility
+        user_msg = payload.get("user_msg")
+        if user_msg is not None:
+            session_id = payload.get("session_id") or new_session_id()
+            answer = chat_fn(session_id, user_msg, model=model)
+            return {"session_id": session_id, "answer": answer}
+
+        raise ValueError("messages must be a list or provide user_msg")
     except Exception as e:
         raise HTTPException(status_code=502, detail=str(e))

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -198,6 +198,7 @@ Missing models will lead to empty embeddings and indexing failures during ingest
 | `/ping`         | GET    | Health check                                 |
 | `/models`       | GET    | List available local LLMs                    |
 | `/chat`         | POST   | Stateful chat w/ session memory              |
+| `/api/chat`     | POST   | Direct Ollama proxy (expects `messages` list) |
 | `/doc_qa`       | POST   | RAG over permanent KB (+ optional session)   |
 | `/upload_pdf`   | POST   | Ingest PDF into ephemeral session store      |
 | `/session/{id}` | DELETE | Purge session store                          |


### PR DESCRIPTION
## Summary
- fallback to `/chat` semantics when POSTing to `/api/chat`
- document that `/api/chat` is a raw Ollama proxy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688133b2d3048329be67db6ee702b39e