### PR TITLE
Document grammar endpoints and 404 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **Session‑based uploads + QA** – Upload a PDF via `/upload_pdf`, then query it with `/session_qa`.
 - **Dynamic retrieval** – Number of retrieved chunks scales with question length (token based).
 - **Offline speech-to-text** – Upload audio to `/speech_to_text` using OpenAI Whisper.
+- **Grammar & rewrite tools** – `/proofread` fixes grammar, `/redraft` rewrites text.
 
 ---
 

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -203,6 +203,10 @@ Missing models will lead to empty embeddings and indexing failures during ingest
 | `/upload_pdf`   | POST   | Ingest PDF into ephemeral session store      |
 | `/session/{id}` | DELETE | Purge session store                          |
 | `/session_qa`   | POST   | RAG over ephemeral + persistent KB           |
+| `/proofread`    | POST   | Grammar correction                           |
+| `/redraft`      | POST   | Proofread + rewrite                          |
+| `/speech_to_text` | POST | Transcribe audio to text                     |
+| `/grammar_check` | POST  | Alias for `/proofread`                       |
 
 The frontend container proxies these endpoints under `/api`, e.g. `/api/models`.
 
@@ -303,11 +307,19 @@ Invoke-RestMethod `
   ```bash
   docker network inspect offlinellm_rag-net
   ```
- "Connection refused" on `curl http://localhost:8000/...` usually means the
+"Connection refused" on `curl http://localhost:8000/...` usually means the
   backend is still waiting for Ollama. Check container status:
   ```bash
   docker compose ps
   docker logs rag-app
+  ```
+- "404 Not Found" when calling an endpoint? Ensure you're using the `/api`
+  prefix when accessing the app through Nginx (`https://localhost/api/...`). If
+  you recently pulled new code, rebuild the backend image so new routes are
+  available:
+  ```bash
+  docker compose build rag-app
+  docker compose up -d rag-app
   ```
 ---
 


### PR DESCRIPTION
## Summary
- document `/proofread` and `/redraft` endpoints
- add `/speech_to_text` and `/grammar_check` to API table
- explain how to troubleshoot 404 errors when using Nginx proxy
- list grammar & rewrite tools in the README

## Testing
- `pytest tests/test_redraft.py tests/test_proofread.py -q` *(fails: ModuleNotFoundError / IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_68813f9c09d48329ada7395caf843b23