### PR TITLE
Fix CrossEncoder init error

### DIFF
--- a/app/rerank.py
+++ b/app/rerank.py
@@ -17,7 +17,14 @@ def _cross() -> CrossEncoder:
     """Return a cached cross-encoder instance."""
     try:
         logging.info("Loading cross-encoder from %s on %s", MODEL_DIR, DEVICE)
-        return CrossEncoder(MODEL_DIR, device=DEVICE, local_files_only=True)
+        try:
+            return CrossEncoder(MODEL_DIR, device=DEVICE, local_files_only=True)
+        except TypeError:
+            # older sentence-transformers versions do not support local_files_only
+            logging.debug(
+                "CrossEncoder does not accept 'local_files_only'; retrying without"
+            )
+            return CrossEncoder(MODEL_DIR, device=DEVICE)
     except OSError as exc:
         logging.warning("Cross-encoder model missing at %s: %s", MODEL_DIR, exc)
         raise RuntimeError(f"cross-encoder model not found in {MODEL_DIR}") from exc

--- a/tests/test_proofread.py
+++ b/tests/test_proofread.py
@@ -231,7 +231,9 @@ class ClientStub:
         self.app = app
     def post(self, url, json=None):
         import asyncio
-
+        if url == '/proofread':
+            req = api.ProofreadRequest(**json)
+            res = asyncio.get_event_loop().run_until_complete(api.proofread(req))
             return FakeResponse(res.dict())
         raise ValueError('unsupported url')
 tc_mod.TestClient = ClientStub


### PR DESCRIPTION
## Summary
- support older sentence-transformers lacking `local_files_only`
- fix test_proofread stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688185ec00808329832c759116fa713b