### PR TITLE
Fix CrossEncoder init error

### DIFF
--- a/tests/test_proofread.py
+++ b/tests/test_proofread.py
@@ -231,7 +231,9 @@ class ClientStub:
         self.app = app
     def post(self, url, json=None):
         import asyncio
-
+        if url == '/proofread':
+            req = api.ProofreadRequest(**json)
+            res = asyncio.get_event_loop().run_until_complete(api.proofread(req))
             return FakeResponse(res.dict())
         raise ValueError('unsupported url')
 tc_mod.TestClient = ClientStub


### PR DESCRIPTION
## Summary
- support older sentence-transformers lacking `local_files_only`
- fix test_proofread stub
- fail fast when the cross-encoder model is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688185ec00808329832c759116fa713b