### PR TITLE
Fix models API host handling

### DIFF
--- a/app/routes/models.py
+++ b/app/routes/models.py
@@ -1,15 +1,18 @@
+import os
 import httpx
 from fastapi import APIRouter, HTTPException
 from typing import List, Dict
 
 router = APIRouter()
 
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://ollama:11434")
+
 @router.get("/api/models")
 async def list_models() -> List[Dict[str, str | None]]:
     """Return locally available Ollama models filtered for chat usage."""
     try:
         async with httpx.AsyncClient(timeout=30) as client:
-            r = await client.get("http://ollama:11434/api/tags")
+            r = await client.get(f"{OLLAMA_HOST}/api/tags")
         r.raise_for_status()
         raw = r.json()
     except Exception as e:

--- a/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
+++ b/docs/SETUP_AND_TROUBLESHOOTING_GUIDE.md
@@ -168,6 +168,8 @@ List available models (`/models` directly or `/api/models` via Nginx):
 curl http://localhost:8000/models
 curl -k https://localhost/api/models
 ```
+If you run the backend outside Docker, export `OLLAMA_HOST=http://localhost:11434`
+so that `/api/models` can reach the local Ollama service.
 
 ---
 


### PR DESCRIPTION
## Summary
- make `/api/models` respect `OLLAMA_HOST`
- document how to set `OLLAMA_HOST` when running outside Docker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818b884dd883298bfa74ef4f6ef0af