### PR TITLE
Add environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,11 @@ By default the cross-encoder runs on the CPU. Set `CROSS_ENCODER_DEVICE` to
 
 ## 🤝 Contributing
 
+Run `./codex/setup.sh` to install dependencies before running tests.
+
 ```bash
 git checkout -b feature/my-feature
-pip install -r requirements.lock
+./codex/setup.sh  # install dependencies
 pytest -q
 # commit, push, open PR
 ```

--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+python -m pip install --upgrade pip
+pip install -r requirements.lock
+# optional: build frontend dependencies if needed
+# (cd offline-llm-ui && npm install)


### PR DESCRIPTION
## Summary
- add `codex/setup.sh` for dependency installation
- document setup script in the contributing guide

## Testing
- `./codex/setup.sh` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881938a1c3c832988786593214dfea4