### PR TITLE
Improve setup script

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -2,5 +2,21 @@
 set -e
 python -m pip install --upgrade pip
 pip install -r requirements.lock
-# optional: build frontend dependencies if needed
-# (cd offline-llm-ui && npm install)
+
+# install frontend/node dependencies if npm is available
+if command -v npm >/dev/null 2>&1; then
+  echo "Installing frontend dependencies"
+  (
+    cd offline-llm-ui
+    # use npm ci for reproducible installs; fall back gracefully if offline
+    npm ci --no-audit --progress=false || \
+      echo "npm install failed - ensure internet access or cached packages"
+  )
+  # root Node packages (used for tests/lint)
+  if [ -f package-lock.json ]; then
+    npm ci --no-audit --progress=false || \
+      echo "npm install failed - ensure internet access or cached packages"
+  fi
+else
+  echo "npm not found; skipping frontend dependencies"
+fi

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -37,7 +37,16 @@ python -m venv .venv
 python -m pip install --upgrade pip
 ```
 
-> **Activation blocked?**  
+### 2.1 Codex setup script (optional)
+
+If you are running inside the **Codex** environment or want a one-line
+setup of all dependencies, run:
+
+```bash
+./codex/setup.sh
+```
+
+> **Activation blocked?**
 > `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force`
 
 ---


### PR DESCRIPTION
## Summary
- expand `codex/setup.sh` to install frontend dependencies
- document running the setup script in dev instructions

## Testing
- `./codex/setup.sh` *(fails: cannot connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688195671a38832987b0057384383468